### PR TITLE
add second param to player.load(videoId, autoplay)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,14 @@ and
 [`playerVars` parameters](https://developers.google.com/youtube/player_parameters#Parameters)
 for additional documentation about these parameters.
 
-### `player.load(videoId)`
+### `player.load(videoId, [autoplay])`
 
-This function loads and plays the specified `videoId`. An example of a `videoId`
-is `'GKSRyLdjsPA'`.
+This function loads the specified `videoId`. An example of a `videoId` is
+`'GKSRyLdjsPA'`.
+
+Optionally, specify an `autoplay` parameter to indicate whether the video should
+begin playing immediately, or wait for a call to `player.play()`. Default is
+`true`.
 
 This should be the first function called on a new `Player` instance.
 

--- a/index.js
+++ b/index.js
@@ -94,8 +94,9 @@ class YouTubePlayer extends EventEmitter {
     })
   }
 
-  load (videoId) {
+  load (videoId, autoplay) {
     if (this.destroyed) return
+    if (autoplay == null) autoplay = true
 
     this.videoId = videoId
 
@@ -115,7 +116,11 @@ class YouTubePlayer extends EventEmitter {
     if (!this._ready) return
 
     // If the player instance is ready, load the given `videoId`.
-    this._player.loadVideoById(videoId)
+    if (autoplay) {
+      this._player.loadVideoById(videoId)
+    } else {
+      this._player.cueVideoById(videoId)
+    }
   }
 
   play () {


### PR DESCRIPTION
Optionally, specify an `autoplay` parameter to indicate whether the video should begin playing immediately, or wait for a call to `player.play()`. Default is `true`.