### PR TITLE
Added lazy initialization for element and options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,15 +58,27 @@ player.on('playing', () => {
 
 ## API
 
-### `player = new Player(element, [opts])`
+### `player = new Player([element], [opts])`
+
+Valid constructor calls:
+
+```js
+player1 = new Player('selector')
+player2 = new Player('selector', opts)
+player3 = new Player(null, opts)
+player4 = new Player()
+```
 
 Create a new YouTube player. The player will take the place of the HTML element
 `element`. Alternatively, `element` can be a selector string, which will be passed
 to `document.querySelector()`.
 
+The player can be initialized without any arguments as well. However, you need to lazy initialize it before you can `load()` the player
+
 Examples: `#player`, `.youtube-player`, or a DOM node.
 
 Optionally, provide an options object `opts` to customize the player.
+
 
 #### `opts.width` (number)
 
@@ -133,6 +145,27 @@ See:
 and
 [`playerVars` parameters](https://developers.google.com/youtube/player_parameters#Parameters)
 for additional documentation about these parameters.
+
+### `player.setElement(element)`
+
+Can be called to set the DOM node of rendered player lazily. Usage:
+
+```js
+const player = new Player()
+// ... code
+player.setElement('#nodeName')
+player.load('youtubeVideoID')
+```
+
+### `player.setOptions(opts)`
+
+Can be called to set the options of the rendered player lazily. Usage:
+
+```js
+const player = new Player('#nodeName')
+// ... code
+player.setOptions({optionProperties: 'goes-here'})
+```
 
 ### `player.load(videoId, [autoplay])`
 

--- a/index.js
+++ b/index.js
@@ -148,7 +148,15 @@ class YouTubePlayer extends EventEmitter {
        return this.emit(new Error('Player is destroyed. Cannot call setElement'))
     }
 
+    
     const elem = typeof element === 'string' ? document.querySelector(element) : element
+
+    if(this._player) {
+      // Player is already loaded. Cannot initialize
+      return this._destroy(new Error('Illegal setElement call on loaded player. Create new instance'))
+    }
+
+    // otherwise, if lazy loading, just update the ID
 
     this._id = elem.id || 'ytplayer-' + Math.random().toString(16).slice(2, 8)
 


### PR DESCRIPTION
The DOM node in which the player is rendered and the options for the player can be lazily initialized. I found that I needed to do that in my React application because at the time of render, the component is not rendered on the screen but I needed the player instance so that I do not create a new player instance every time I need to change the video ID of the player.

Hope it'll help someone in future.