### PR TITLE
add playsinline option to player params

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,8 @@ class YouTubePlayer extends EventEmitter {
       modestBranding: false,
       related: true,
       info: true,
-      timeupdateFrequency: 1000
+      timeupdateFrequency: 1000,
+      playsInline: true
     }, opts)
 
     this.videoId = null
@@ -364,7 +365,7 @@ class YouTubePlayer extends EventEmitter {
         //        default value, though the default is subject to change.
         //   - 1: This value causes inline playback for UIWebViews created with
         //        the allowsInlineMediaPlayback property set to TRUE.
-        playsinline: 1,
+        playsinline: opts.playsInline ? 1 : 0,
 
         // This parameter indicates whether the player should show related videos
         // when playback of the initial video ends. Supported values are 0 and 1.


### PR DESCRIPTION
Playsinline attribute was previously set to true and was not customizable, so there was no way to allow for fullscreen autoplay on iOS. This PR adds the playsInline option. 