### PR TITLE
Ensure stopVideo exists during destroy

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,7 +222,7 @@ class YouTubePlayer extends EventEmitter {
     this.destroyed = true
 
     if (this._player) {
-      this._player.stopVideo()
+      this._player.stopVideo && this._player.stopVideo()
       this._player.destroy()
     }
 


### PR DESCRIPTION
`_player.stopVideo` may not exist before a video is loaded. Add a
check within `_destroy` to ensure it exists before calling.

Fixes #44