### PR TITLE
Remove deprecated `info` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,12 +124,6 @@ the player. The default value is `false`.
 This parameter indicates whether the player should show related videos when
 playback of the initial video ends. The default value is `true`.
 
-#### `opts.info` (boolean)
-
-This parameter indicates whether the player should display information like the
-video title and uploader before the video starts playing. The default value is
-`true`.
-
 #### `opts.timeupdateFrequency` (number)
 
 The time between `onTimeupdate` callbacks, in milliseconds. Default is `1000`.

--- a/index.js
+++ b/index.js
@@ -65,7 +65,6 @@ class YouTubePlayer extends EventEmitter {
       annotations: true,
       modestBranding: false,
       related: true,
-      info: true,
       timeupdateFrequency: 1000,
       playsInline: true
     }, opts)
@@ -391,15 +390,6 @@ class YouTubePlayer extends EventEmitter {
         // when playback of the initial video ends. Supported values are 0 and 1.
         // The default value is 1.
         rel: opts.related ? 1 : 0,
-
-        // Supported values are 0 and 1. Setting the parameter's value to 0
-        // causes the player to not display information like the video title and
-        // uploader before the video starts playing. If the player is loading a
-        // playlist, and you explicitly set the parameter value to 1, then, upon
-        // loading, the player will also display thumbnail images for the videos
-        // in the playlist. Note that this functionality is only supported for
-        // the AS3 player.
-        showinfo: opts.info ? 1 : 0,
 
         // (Not part of documented API) Allow html elements with higher z-index
         // to be shown on top of the YouTube player.


### PR DESCRIPTION
`showInfo` was deprecated from the IFrame API on August 23, 2018 and has
been ignored since September 25, 2018. Remove the `info` option to align
with the change.

https://developers.google.com/youtube/player_parameters#release_notes_08_23_2018