### PR TITLE
Provide option to start a video from a given time

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,15 @@ for additional documentation about these parameters.
 
 This parameter controls whether videos play inline or fullscreen in an HTML5 player on iOS. The default value is `true`.
 
-### `player.load(videoId, [autoplay])`
+#### `opts.start` (number)
+
+This parameter causes the player to begin playing the video at the given number
+of seconds from the start of the video. The parameter value is a positive integer.
+Note that the player will look for the closest keyframe to the time you specify.
+This means that sometimes the play head may seek to just before the requested time,
+usually no more than around two seconds.
+
+### `player.load(videoId, [autoplay, start])`
 
 This function loads the specified `videoId`. An example of a `videoId` is
 `'GKSRyLdjsPA'`.
@@ -149,6 +157,9 @@ This function loads the specified `videoId`. An example of a `videoId` is
 Optionally, specify an `autoplay` parameter to indicate whether the video should
 begin playing immediately, or wait for a call to `player.play()`. Default is
 `false`.
+
+The optional `start` parameter accepts a float/integer. If it is specified,
+then the video will start from the closest keyframe to the specified time.
 
 This should be the first function called on a new `Player` instance.
 

--- a/README.md
+++ b/README.md
@@ -156,9 +156,7 @@ This function loads the specified `videoId`. An example of a `videoId` is
 
 Optionally, specify an `autoplay` parameter to indicate whether the video should
 begin playing immediately, or wait for a call to `player.play()`. Default is
-`false`.
-
-The optional `start` parameter accepts a float/integer. If it is specified,
+`false`. The optional `start` parameter accepts a float/integer. If it is specified,
 then the video will start from the closest keyframe to the specified time.
 
 This should be the first function called on a new `Player` instance.

--- a/index.js
+++ b/index.js
@@ -66,7 +66,8 @@ class YouTubePlayer extends EventEmitter {
       modestBranding: false,
       related: true,
       timeupdateFrequency: 1000,
-      playsInline: true
+      playsInline: true,
+      start: undefined
     }, opts)
 
     this.videoId = null
@@ -97,15 +98,16 @@ class YouTubePlayer extends EventEmitter {
 
       // If load(videoId, [autoplay]) was called before Iframe API loaded, ensure it gets
       // called again now
-      if (this.videoId) this.load(this.videoId, this._autoplay)
+      if (this.videoId) this.load(this.videoId, this._autoplay, this._start)
     })
   }
 
-  load (videoId, autoplay = false) {
+  load (videoId, autoplay = false, start) {
     if (this.destroyed) return
 
     this.videoId = videoId
     this._autoplay = autoplay
+    this._start = start
 
     // If the Iframe API is not ready yet, do nothing. Once the Iframe API is
     // ready, `load(this.videoId)` will be called.
@@ -124,9 +126,9 @@ class YouTubePlayer extends EventEmitter {
 
     // If the player instance is ready, load the given `videoId`.
     if (autoplay) {
-      this._player.loadVideoById(videoId)
+      this._player.loadVideoById(videoId, start)
     } else {
-      this._player.cueVideoById(videoId)
+      this._player.cueVideoById(videoId, start)
     }
   }
 
@@ -393,7 +395,14 @@ class YouTubePlayer extends EventEmitter {
 
         // (Not part of documented API) Allow html elements with higher z-index
         // to be shown on top of the YouTube player.
-        wmode: 'opaque'
+        wmode: 'opaque',
+
+        // This parameter causes the player to begin playing the video at the given number 
+        // of seconds from the start of the video. The parameter value is a positive integer.
+        // Note that similar to the seekTo function, the player will look for the closest
+        // keyframe to the time you specify. This means that sometimes the play head may seek
+        // to just before the requested time, usually no more than around two seconds.
+        start: opts.start
       },
       events: {
         onReady: () => this._onReady(videoId),
@@ -426,7 +435,7 @@ class YouTubePlayer extends EventEmitter {
     //   3. `load(videoId, [autoplay])` was called multiple times before the player
     //      was ready. Therefore, the player was initialized with the wrong videoId,
     //      so load the latest videoId and potentially autoplay it.
-    this.load(this.videoId, this._autoplay)
+    this.load(this.videoId, this._autoplay, this._start)
 
     this._flushQueue()
   }

--- a/index.js
+++ b/index.js
@@ -399,7 +399,7 @@ class YouTubePlayer extends EventEmitter {
 
         // This parameter causes the player to begin playing the video at the given number 
         // of seconds from the start of the video. The parameter value is a positive integer.
-        // Note that similar to the seekTo function, the player will look for the closest
+        // Note that similar to the seek function, the player will look for the closest
         // keyframe to the time you specify. This means that sometimes the play head may seek
         // to just before the requested time, usually no more than around two seconds.
         start: opts.start


### PR DESCRIPTION
When I want to start a video from a specific time, I have to manually call the seek function after the player has been initialized. This doesn't always go smooth, since the video has to be playing first. The Youtube Iframe API has a start parameter to start a video from a given number of seconds. This package does not implement this option.  In this PR, I've added this option to the playerVars and as a parameter to the load method. They are both optional.