### PR TITLE
Add host to player options to allow a better GDPR / privacy friendly loading of YouTube videos

### DIFF
--- a/index.js
+++ b/index.js
@@ -298,6 +298,7 @@ class YouTubePlayer extends EventEmitter {
     const opts = this._opts
 
     this._player = new this._api.Player(this._id, {
+      host: opts.host,
       width: opts.width,
       height: opts.height,
       videoId: videoId,


### PR DESCRIPTION
The `host` is a rather undocumented option, I like to think that they also changed their motto `Don't be evil` because of this 😄 

The default value that is in their `http://www.youtube.com/iframe_api` js file is `http://www.youtube.com`

You can find mentions of `www.youtube-nocookie.com` in the loaded js from the iframe_API https://s.ytimg.com/yts/jsbin/www-widgetapi-vfljTd96t/www-widgetapi.js
<img width="962" alt="Screen Shot 2020-06-04 at 15 37 11" src="https://user-images.githubusercontent.com/1328733/83763697-49585200-a679-11ea-9244-2af6748acfcf.png">

And also on the official youtube.com website 
<img width="864" alt="Screen Shot 2020-06-04 at 14 54 36" src="https://user-images.githubusercontent.com/1328733/83763746-58d79b00-a679-11ea-91a6-4fee69520585.png">
<img width="861" alt="Screen Shot 2020-06-04 at 14 54 42" src="https://user-images.githubusercontent.com/1328733/83763776-60973f80-a679-11ea-9460-51f1847f9368.png">
<img width="243" alt="Screen Shot 2020-06-04 at 14 57 57" src="https://user-images.githubusercontent.com/1328733/83763786-642ac680-a679-11ea-9933-41273a754bd7.png">


```js
new YTPlayer('#player', {
	host: 'https://www.youtube-nocookie.com',
	modestBranding: true,
	related: false,
})
```

I have an edit ready for the DefinitelyTyped types later when this gets in 😃

Of course I tried it and it works as expected 💯 