### PR TITLE
fix error code checking from YT API

### DIFF
--- a/index.js
+++ b/index.js
@@ -496,7 +496,7 @@ class YouTubePlayer extends EventEmitter {
   _onError (data) {
     if (this.destroyed) return
 
-    const code = data.data
+    const code = Number(data.data)
 
     // The HTML5_ERROR error occurs when the YouTube player needs to switch from
     // HTML5 to Flash to show an ad. Ignore it.


### PR DESCRIPTION
The Youtube API returns strings, not numbers, in their `data` property (this is not made clear by their documentation). Not sure if this is something that changed recently or if it's always been this way, but you can reproduce this issue by embedding any age-restricted Youtube video.

I tested this change and it seems to work properly when we embed an age-restricted video, showing the age warning instead of a blank div.